### PR TITLE
feat(cardano): read transactions and metadata from Cardano via Blockfrost / feat(cardano): lectura de transacciones y metadata desde Blockfrost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# =========================
+# ASP.NET Core / Visual Studio
+# =========================
+.vs/
+bin/
+obj/
+
+# =========================
+# App settings sensibles
+# =========================
+appsettings.Development.json
+appsettings.Local.json
+*.local.json
+
+# =========================
+# Environment variables
+# =========================
+.env
+.env.*
+
+# =========================
+# Logs
+# =========================
+*.log
+logs/
+
+# =========================
+# OS / Editor
+# =========================
+.DS_Store
+Thumbs.db
+
+# =========================
+# Node (por si luego agregas frontend)
+# =========================
+node_modules/

--- a/AsuncionIpfs/Config/BlockfrostOptions.cs
+++ b/AsuncionIpfs/Config/BlockfrostOptions.cs
@@ -1,0 +1,19 @@
+﻿namespace AsuncionIpfs.Config
+{
+    public class BlockfrostOptions
+    {
+        public string Network { get; set; } = "preview";
+        public BlockfrostCardanoOptions Cardano { get; set; } = new();
+        public BlockfrostIpfsOptions Ipfs { get; set; } = new();
+    }
+
+    public class BlockfrostCardanoOptions
+    {
+        public string ApiKey { get; set; } = "";
+    }
+
+    public class BlockfrostIpfsOptions
+    {
+        public string ApiKey { get; set; } = "";
+    }
+}

--- a/AsuncionIpfs/Constants.cs
+++ b/AsuncionIpfs/Constants.cs
@@ -11,8 +11,11 @@
         // SUPPORTEF ENVIRONMENT VARIABLES
         public const string ENV_ENVIRONMENT = "NETCORE_ENVIRONMENT";
         public const string ENV_BF_RATE_LIMIT = "BF_RATE_LIMIT";
-        public const string ENV_BFCLI_API_KEY = "";
+        public const string ENV_BFCLI_API_KEY = "BFCLI_API_KEY";
         public const string ENV_BFCLI_NETWORK = "BFCLI_NETWORK";
+
+        // CARDANO API
+        public const string ENV_BF_CARDANO_API_KEY = "BF_CARDANO_API_KEY";
 
         // NETWORK NAMES
         public const string NETWORK_MAINNET = "mainnet";

--- a/AsuncionIpfs/Controllers/CardanoController.cs
+++ b/AsuncionIpfs/Controllers/CardanoController.cs
@@ -1,0 +1,57 @@
+﻿using AsuncionIpfs.Services.Cardano;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+using AsuncionIpfs.Dtos;
+
+
+namespace AsuncionIpfs.Controllers
+{
+    [ApiController]
+    [Route("api/traceability")]
+    public class TraceabilityController : ControllerBase
+    {
+        private readonly BlockfrostService _blockfrost;
+
+        public TraceabilityController(BlockfrostService blockfrost)
+        {
+            _blockfrost = blockfrost;
+        }
+
+        [HttpGet("tx-metadata")]
+        public async Task<IActionResult> TxMetadata([FromQuery] string txHash, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(txHash))
+                return BadRequest(new { message = "txHash es requerido" });
+
+            JsonElement raw = await _blockfrost.GetTxMetadataRawAsync(txHash, ct);
+
+            // Normalizamos a DTO: label + json
+            var labels = new List<TxMetadataLabelDto>();
+
+            foreach (var item in raw.EnumerateArray())
+            {
+                var label = item.TryGetProperty("label", out var l) ? (l.GetString() ?? "") : "";
+                object? json = null;
+
+                if (item.TryGetProperty("json_metadata", out var jm))
+                    json = JsonSerializer.Deserialize<object>(jm.GetRawText());
+
+                labels.Add(new TxMetadataLabelDto
+                {
+                    label = label,
+                    json = json
+                });
+            }
+
+            var dto = new TxMetadataDto
+            {
+                txHash = txHash,
+                network = _blockfrost.GetNetworkName(),
+                labels = labels
+            };
+
+            return Ok(dto);
+        }
+    }
+}

--- a/AsuncionIpfs/Controllers/IpfsController.cs
+++ b/AsuncionIpfs/Controllers/IpfsController.cs
@@ -18,10 +18,10 @@ namespace AsuncionIpfs.Controllers
         }
 
         [HttpPost("upload")]
+        [Consumes("multipart/form-data")]
         public async Task<IActionResult> UploadFile(IFormFile file)
         {
-            string tempFilePath = null;
-
+            string tempFilePath = null;          
             try
             {
                 if (file == null || file.Length == 0)
@@ -49,6 +49,7 @@ namespace AsuncionIpfs.Controllers
             {
                 
                 return StatusCode(500, $"Internal server error: {ex.Message}");
+               
             }
             finally
             {

--- a/AsuncionIpfs/Dtos/Transaccion.Dtos.cs
+++ b/AsuncionIpfs/Dtos/Transaccion.Dtos.cs
@@ -1,0 +1,15 @@
+﻿namespace AsuncionIpfs.Dtos
+{
+    public class TxMetadataDto
+    {
+        public string txHash { get; set; } = "";
+     public string network { get; set; } = "";
+        public List<TxMetadataLabelDto> labels { get; set; } = new();
+    }
+
+    public class TxMetadataLabelDto
+    {
+     public string label { get; set; } = "";
+     public object? json { get; set; }
+    }
+}

--- a/AsuncionIpfs/Program.cs
+++ b/AsuncionIpfs/Program.cs
@@ -1,38 +1,62 @@
-using AsuncionIpfs.Services;
+ï»¿using AsuncionIpfs.Services;
 using AsuncionIpfs.Services.IPFS;
-using Blockfrost.Api.Services;
+using AsuncionIpfs.Services.Cardano;
 using Microsoft.AspNetCore.Http.Features;
+using System.Net.Http.Headers;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.Configure<FormOptions>(options =>
 {
-    options.MultipartBodyLengthLimit = 268435456; // 256 MB, ajusta según sea necesario
+    options.MultipartBodyLengthLimit = 268435456;
 });
 
-builder.Services.AddSingleton<IHealthService, HealthService>(); // Asegúrate de tener una implementación de HealthService
-builder.Services.AddSingleton<IMetricsService, MetricsService>(); // Asegúrate de tener una implementación de MetricsService
-
-builder.Services.AddHttpClient<AsuncionIpfs.Services.IAddService, AsuncionIpfs.Services.IPFS.AddService>(client =>
+// IPFS client
+builder.Services.AddHttpClient<IAddService, AddService>((sp, client) =>
 {
-    client.BaseAddress = new Uri("https://ipfs.blockfrost.io");
+    var cfg = sp.GetRequiredService<IConfiguration>();
+    var ipfsKey = cfg["Blockfrost:Ipfs:ApiKey"];
+
+    if (string.IsNullOrWhiteSpace(ipfsKey))
+        throw new Exception("Falta Blockfrost:Ipfs:ApiKey en appsettings.json");
+
+    client.BaseAddress = new Uri("https://ipfs.blockfrost.io/api/v0/");
+    client.DefaultRequestHeaders.Add("project_id", ipfsKey);
+    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 });
 
+// Cardano client (tu servicio actual)
+builder.Services.AddHttpClient<BlockfrostService>(client => { })
+.ConfigureHttpClient((sp, client) =>
+{
+    var cfg = sp.GetRequiredService<IConfiguration>();
 
+    var network = (cfg["Blockfrost:Network"] ?? "preview").ToLowerInvariant();
+    var cardanoKey = cfg["Blockfrost:Cardano:ApiKey"];
 
+    if (string.IsNullOrWhiteSpace(cardanoKey))
+        throw new Exception("Falta Blockfrost:Cardano:ApiKey en appsettings.json");
 
-// Add services to the container.
+    var baseUrl = network switch
+    {
+        "preview" => "https://cardano-preview.blockfrost.io/api/v0/",
+        "preprod" => "https://cardano-preprod.blockfrost.io/api/v0/",
+        _ => "https://cardano-mainnet.blockfrost.io/api/v0/"
+    };
+
+    client.BaseAddress = new Uri(baseUrl);
+    client.DefaultRequestHeaders.Add("project_id", cardanoKey);
+    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+});
+
+// CORS + ASP.NET
+builder.Services.AddCors(o => o.AddPolicy("AllowAll", p => p.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
 builder.Services.AddControllers();
-
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Logging.ClearProviders();
-builder.Logging.AddConsole();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -41,9 +65,8 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseRouting();
-app.UseHttpsRedirection();
+app.UseCors("AllowAll");
 app.UseAuthorization();
 app.MapControllers();
-
 
 app.Run();

--- a/AsuncionIpfs/Services/Cardano/BlockfrostService.cs
+++ b/AsuncionIpfs/Services/Cardano/BlockfrostService.cs
@@ -1,0 +1,37 @@
+﻿using System.Net.Http.Headers;
+using System.Text.Json;
+namespace AsuncionIpfs.Services.Cardano
+{
+    public class BlockfrostService
+    {
+        private readonly HttpClient _http;
+        private readonly string _network;
+
+        public BlockfrostService(HttpClient http, IConfiguration cfg)
+        {
+            _http = http;
+            _network = (cfg["Blockfrost:Network"] ?? "preview").ToLowerInvariant();
+        }
+
+        public string GetNetworkName() => _network;
+
+        /// <summary>
+        /// Blockfrost devuelve:
+        /// [{ "label": "674", "json_metadata": {...} }, ...]
+        /// </summary>
+        public async Task<JsonElement> GetTxMetadataRawAsync(string txHash, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(txHash))
+                throw new ArgumentException("txHash es requerido", nameof(txHash));
+
+            var res = await _http.GetAsync($"txs/{txHash}/metadata", ct);
+            var body = await res.Content.ReadAsStringAsync(ct);
+
+            if (!res.IsSuccessStatusCode)
+                throw new Exception($"Blockfrost error ({(int)res.StatusCode}): {body}");
+
+            using var doc = JsonDocument.Parse(body);
+            return doc.RootElement.Clone();
+        }
+    }
+}

--- a/AsuncionIpfs/Services/IAddService.cs
+++ b/AsuncionIpfs/Services/IAddService.cs
@@ -2,36 +2,15 @@
 using System.Threading;
 using System.Threading.Tasks;
 using AsuncionIpfs.Models.IPFS;
-using Blockfrost.Api;
-using Blockfrost.Api.Http;
-using Blockfrost.Api.Models;
-using Blockfrost.Api.Services;
 
 namespace AsuncionIpfs.Services
 {
-    public partial interface IAddService : IBlockfrostService
+    public interface IAddService
     {
-        IHealthService Health { get; set; }
-        IMetricsService Metrics { get; set; }
-
-        /// <summary>
-        ///     Add a file to IPFS <c>/ipfs/add</c>
-        /// </summary>
-        /// <remarks>
-        ///     See also <seealso href="https://docs.blockfrost.io/#tag/IPFS-Add/paths/~1ipfs~1add/post">/ipfs/add</seealso> on docs.blockfrost.io
-        /// </remarks>
-        /// <returns>Returns information about added IPFS object</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        [Post("/ipfs/add", "0.1.28")]
         Task<AddContentResponse> PostAddAsync(FileStream stream, CancellationToken cancellationToken = default);
-        
-        [Post("/ipfs/pin/add/{IPFS_path}", "0.1.28")]
+
         Task<PinStateContentResponse> PostPinAddAsync(string ipfsPath, CancellationToken cancellationToken = default);
 
-        [Get("/ipfs/gateway/{IPFS_path}", "0.1.28")]
         Task<object> GetGatewayAsync(string ipfsPath, CancellationToken cancellationToken = default);
-
-
     }
-
 }

--- a/AsuncionIpfs/Services/IPFS/AddService.cs
+++ b/AsuncionIpfs/Services/IPFS/AddService.cs
@@ -1,277 +1,86 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AsuncionIpfs.Models.IPFS;
-using AsuncionIpfs.Utils;
-using Blockfrost.Api;
-using Blockfrost.Api.Extensions;
-using Blockfrost.Api.Http;
-using Blockfrost.Api.Services;
-using Blockfrost.Api.Utils;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using AsuncionIpfs.Services;
 
 namespace AsuncionIpfs.Services.IPFS
 {
-    public partial class AddService : ABlockfrostService,IAddService
+    public class AddService : IAddService
     {
-       
-        /// <summary> 
-        ///     Initializes a new <see cref="AddService"></see> with the specified <see cref="HttpClient"></see> 
-        /// </summary>
-        /// <remarks>
-        ///     See also <seealso href="https://docs.blockfrost.io/#tag/IPFS-Add">IPFS » Add</seealso> on docs.blockfrost.io
-        /// </remarks>
-        public AddService(IHealthService health, IMetricsService metrics, HttpClient httpClient) : base(httpClient)
+        private readonly HttpClient _http;
+
+        private static readonly JsonSerializerOptions JsonOpts = new()
         {
-            Health = health;
-            Metrics = metrics;
+            PropertyNameCaseInsensitive = true
+        };
+
+        public AddService(HttpClient http)
+        {
+            _http = http;
         }
 
-        public IHealthService Health { get; set; }
-
-        public IMetricsService Metrics { get; set; }
-
-        /// <summary>
-        ///     Add a file to IPFS <c>/ipfs/add</c>
-        /// </summary>
-        /// <remarks>
-        ///     See also <seealso href="https://docs.blockfrost.io/#tag/IPFS-Add/paths/~1ipfs~1add/post">/ipfs/add</seealso> on docs.blockfrost.io
-        /// </remarks>
-        /// <returns>Returns information about added IPFS object</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        [Post("/ipfs/add", "0.1.28")]
-        public async Task<Models.IPFS.AddContentResponse> PostAddAsync(FileStream stream, CancellationToken cancellationToken = default)
+        // POST https://ipfs.blockfrost.io/api/v0/ipfs/add
+        public async Task<AddContentResponse> PostAddAsync(FileStream stream, CancellationToken cancellationToken = default)
         {
-            // Construir la URL de la API
-            var builder = GetUrlBuilder("/api/v0/ipfs/add");
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
 
-            // Preparar el contenido multipart/form-data
-            var content = PrepareHttpContent(stream);
+            using var form = new MultipartFormDataContent();
+            using var fileContent = new StreamContent(stream);
+            form.Add(fileContent, "file", "uploaded_file");
 
-            // Agregar el encabezado `project_id`
-            content.Headers.Add("project_id", Constants.ENV_BFCLI_API_KEY);
+            using var resp = await _http.PostAsync("ipfs/add", form, cancellationToken).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-            // Enviar la solicitud utilizando SendPostRequestAsync
-            return await SendPostRequestAsync<Models.IPFS.AddContentResponse>(content, builder, cancellationToken);
+            if (!resp.IsSuccessStatusCode)
+                throw new HttpRequestException($"IPFS add falló ({(int)resp.StatusCode}): {body}");
+
+            var result = JsonSerializer.Deserialize<AddContentResponse>(body, JsonOpts);
+            return result ?? throw new Exception("Respuesta nula en /ipfs/add");
         }
 
-        [Post("/ipfs/pin/add/{IPFS_path}", "0.1.28")]
-        public async Task<PinStateContentResponse> PostPinAddAsync(string ipfsPath, CancellationToken cancellationToken)
+        // POST https://ipfs.blockfrost.io/api/v0/ipfs/pin/add/{ipfsPath}
+        public async Task<PinStateContentResponse> PostPinAddAsync(string ipfsPath, CancellationToken cancellationToken = default)
         {
-            var builder = GetUrlBuilder("/api/v0/ipfs/pin/add/{IPFS_path}");
-            _ = builder.SetRouteParameter("{IPFS_path}", ipfsPath);
+            if (string.IsNullOrWhiteSpace(ipfsPath))
+                throw new ArgumentException("ipfsPath requerido", nameof(ipfsPath));
 
-            var content = PreparePinHttpContent();
-            content.Headers.Add("project_id", Constants.ENV_BFCLI_API_KEY);
+            using var content = new StringContent(string.Empty);
+            var safePath = Uri.EscapeDataString(ipfsPath);
 
-            return await SendPostRequestAsync<PinStateContentResponse>(content, builder, cancellationToken);
+            using var resp = await _http.PostAsync($"ipfs/pin/add/{safePath}", content, cancellationToken).ConfigureAwait(false);
+            var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
+            if (!resp.IsSuccessStatusCode)
+                throw new HttpRequestException($"IPFS pin add falló ({(int)resp.StatusCode}): {body}");
+
+            var result = JsonSerializer.Deserialize<PinStateContentResponse>(body, JsonOpts);
+            return result ?? throw new Exception("Respuesta nula en /ipfs/pin/add");
         }
-       
-        [Get("/ipfs/gateway/{IPFS_path}", "0.1.28")]
+
+        // GET https://ipfs.blockfrost.io/api/v0/ipfs/gateway/{ipfsPath}
+        // OJO: tu controller espera "object" pero maneja byte[]; devolvemos byte[].
         public async Task<object> GetGatewayAsync(string ipfsPath, CancellationToken cancellationToken = default)
         {
-            if (ipfsPath == null)
+            if (string.IsNullOrWhiteSpace(ipfsPath))
+                throw new ArgumentException("ipfsPath requerido", nameof(ipfsPath));
+
+            var safePath = Uri.EscapeDataString(ipfsPath);
+
+            using var resp = await _http.GetAsync($"ipfs/gateway/{safePath}", cancellationToken).ConfigureAwait(false);
+
+            if (!resp.IsSuccessStatusCode)
             {
-                throw new System.ArgumentNullException(nameof(ipfsPath));
+                var body = await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                throw new HttpRequestException($"IPFS gateway falló ({(int)resp.StatusCode}): {body}");
             }
 
-            var builder = GetUrlBuilder("/api/v0/ipfs/gateway/{IPFS_path}");
-            _ = builder.SetRouteParameter("{IPFS_path}", ipfsPath);
-
-            return await SendGetRequestAsync<object>(builder, cancellationToken);
-
-                         
-
+            // Blockfrost gateway normalmente devuelve bytes (octet-stream / image/*)
+            var bytes = await resp.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            return bytes;
         }
-
-
-        protected HttpContent PrepareHttpContent(Stream stream)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            // Crear el contenido multipart/form-data
-            var content = new MultipartFormDataContent();
-            content.Add(new StreamContent(stream), "file", "uploaded_file");
-            // No configures el Content-Type aquí; se manejará automáticamente por MultipartFormDataContent
-            return content;
-        }
-        protected HttpContent PreparePinHttpContent()
-        {
-            var content = new StringContent("", null, "text/plain");
-            return content;
-        }
-        protected async Task<TResponse> SendGetRequestAsync<TResponse>(StringBuilder builder, CancellationToken cancellationToken)
-        {
-            using var request = new HttpRequestMessage();
-            request.Method = new HttpMethod("GET");
-            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
-            request.Headers.Add("project_id", Constants.ENV_BFCLI_API_KEY);
-
-
-            return await SendRequestAsync<TResponse>(builder, request, cancellationToken).ConfigureAwait(false);
-        }
-        private async Task<TResponse> SendRequestAsync<TResponse>(StringBuilder builder, HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            string url = builder.ToString();
-            request.RequestUri = new Uri(url, UriKind.RelativeOrAbsolute);
-
-            PrepareRequest(HttpClient, request, builder);
-
-            var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-
-            bool disposeResponse = true;
-            try
-            {
-                var headers = ProcessResponseHeaders(response);
-
-                ProcessResponse(HttpClient, response);
-
-                return await ReadResponseAsync<TResponse>(response, headers, cancellationToken);
-            }
-            finally
-            {
-                if (disposeResponse)
-                {
-                    response.Dispose();
-                }
-            }
-        }
-
-        private static Dictionary<string, IEnumerable<string>> ProcessResponseHeaders(HttpResponseMessage response)
-        {
-            var headers = System.Linq.Enumerable.ToDictionary(response.Headers, header => header.Key, header => header.Value);
-
-            if (response.Content == null || response.Content.Headers == null)
-            {
-                return headers;
-            }
-
-            foreach (var item in response.Content.Headers)
-            {
-                headers[item.Key] = item.Value;
-            }
-
-            return headers;
-        }
-
-        private async Task<TResponse> ReadResponseAsync<TResponse>(HttpResponseMessage response, Dictionary<string, IEnumerable<string>> headers, CancellationToken cancellationToken)
-        {
-            int statusCode = (int)response.StatusCode;
-            switch (statusCode) 
-            {
-                case 200:
-                    {
-                        if (response.Content.Headers.ContentType.MediaType.StartsWith("image/") ||
-                        response.Content.Headers.ContentType.MediaType == "application/octet-stream")
-                        {
-                            var byteArray = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-                            return (TResponse)(object)byteArray;
-                        }
-
-
-                        // Continuar con el procesamiento normal para otros tipos de respuesta
-                        var objectResponse = await ReadObjectResponseAsync<TResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        return objectResponse.Value == null
-                            ? throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null)
-                            : objectResponse.Value;
-                    }
-
-                case 202:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<TResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        return objectResponse.Value == null
-                            ? throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null)
-                            : objectResponse.Value;
-                    }
-
-                case 400:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<BadRequestResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<BadRequestResponse>("Bad request", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                case 403:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<ForbiddenResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<ForbiddenResponse>("Authentication secret is missing or invalid", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                case 404:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<NotFoundResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<NotFoundResponse>("Component not found", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                case 418:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<UnsupportedMediaTypeResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<UnsupportedMediaTypeResponse>("IP has been auto-banned for extensive sending of requests after usage limit has been reached", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                case 429:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<TooManyRequestsResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<TooManyRequestsResponse>("Usage limit reached", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                case 500:
-                    {
-                        var objectResponse = await ReadObjectResponseAsync<InternalServerErrorResponse>(response, headers, cancellationToken).ConfigureAwait(false);
-                        if (objectResponse.Value == null)
-                        {
-                            throw new ApiException("Response was null which was not expected.", statusCode, objectResponse.Text, headers, null);
-                        }
-
-                        throw new ApiException<InternalServerErrorResponse>("Internal Server Error", statusCode, objectResponse.Text, headers, objectResponse.Value, null);
-                    }
-
-                default:
-                    {
-                        string responseData = response.Content == null ? null : await response.Content
-#if NET5_0_OR_GREATER
-                            .ReadAsStringAsync(cancellationToken)
-#else
-                            .ReadAsStringAsync()
-#endif
-                            .ConfigureAwait(false);
-                        throw new ApiException("The HTTP status code of the response was not expected (" + statusCode + ").", statusCode, responseData, headers, null);
-                    }
-            }
-        }
-
-
     }
 }

--- a/AsuncionIpfs/appsettings.Development.json
+++ b/AsuncionIpfs/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/AsuncionIpfs/appsettings.json
+++ b/AsuncionIpfs/appsettings.json
@@ -5,5 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "Blockfrost": {
+    "Network": "preview",
+    "Cardano": {
+      "ApiKey": ""
+    },
+    "Ipfs": {
+      "ApiKey": ""
+    }
+  }
 }


### PR DESCRIPTION
(EN) This update adds support for reading transactions from the Cardano blockchain using Blockfrost.

Main changes:
- Read Cardano transaction data using txHash.
- Retrieve on-chain metadata associated with a transaction.
- Blockfrost integration using a typed configuration (Options pattern).
- Clear separation between IPFS and Cardano services.
- Secure configuration without exposing API keys in the repository.

This enables on-chain traceability for processes that rely on Cardano transactions.

(ES) Se incorpora la lectura de transacciones en la blockchain de Cardano utilizando Blockfrost.

Cambios principales:
- Lectura de información de transacciones (txHash) desde Cardano.
- Obtención de metadata on-chain asociada a la transacción.
- Integración de Blockfrost mediante configuración tipada (Options pattern).
- Separación de responsabilidades entre servicios IPFS y Cardano.
- Configuración segura de credenciales sin exponer API keys en el repositorio.

Este cambio habilita la trazabilidad on-chain de procesos que dependen de transacciones Cardano.

